### PR TITLE
Quick and dirty edit for running main.py without fbs

### DIFF
--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -7,6 +7,7 @@ from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
 from intellimouse import IntelliMouse
 import sys
+import os
 
 class QIntModuloValidator(QIntValidator):
 	def __init__(self, modulo, *args, **kwargs):
@@ -118,7 +119,7 @@ class MainWindow(QMainWindow):
 		try:
 			self.errorWindow = ErrorWindow(self.applicationContext.get_resource('error.png'), self)
 		except:
-			self.errorWindow = ErrorWindow('../resources/base/error.png', self)
+			self.errorWindow = ErrorWindow(os.path.dirname(os.path.abspath(__file__)) + '/../resources/base/error.png', self)
 		self.setCentralWidget(self.errorWindow)
 		self.setFixedSize(self.sizeHint())
 		self.errorWindow.retryButton.clicked.connect(self.showAppropriateLayout)

--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -188,7 +188,7 @@ if __name__ == '__main__':
 	try:
 		applicationContext = ApplicationContext()
 	except:
-		applicationContext = QApplication(sys.argv)
+		applicationContext = QApplication('Pro IntelliMouse Control Panel')
 	window = MainWindow(applicationContext)
 	exit_code = -1
 	try:

--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -188,7 +188,8 @@ if __name__ == '__main__':
 	try:
 		applicationContext = ApplicationContext()
 	except:
-		applicationContext = QApplication('Pro IntelliMouse Control Panel')
+		sys.argv[0] = 'Control Panel for Microsoft IntelliMouse Pro'
+		applicationContext = QApplication(sys.argv)
 	window = MainWindow(applicationContext)
 	exit_code = -1
 	try:

--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -1,4 +1,7 @@
-from fbs_runtime.application_context.PyQt5 import ApplicationContext
+try:
+	from fbs_runtime.application_context.PyQt5 import ApplicationContext
+except:
+	pass
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
@@ -112,7 +115,10 @@ class MainWindow(QMainWindow):
 				self.showErrorWindow()
 
 	def showErrorWindow(self):
-		self.errorWindow = ErrorWindow(self.applicationContext.get_resource('error.png'), self)
+		try:
+			self.errorWindow = ErrorWindow(self.applicationContext.get_resource('error.png'), self)
+		except:
+			self.errorWindow = ErrorWindow('../resources/base/error.png', self)
 		self.setCentralWidget(self.errorWindow)
 		self.setFixedSize(self.sizeHint())
 		self.errorWindow.retryButton.clicked.connect(self.showAppropriateLayout)
@@ -177,7 +183,15 @@ class MainWindow(QMainWindow):
 		self.show()
 
 if __name__ == '__main__':
-	applicationContext = ApplicationContext()
+	applicationContext = None
+	try:
+		applicationContext = ApplicationContext()
+	except:
+		applicationContext = QApplication(sys.argv)
 	window = MainWindow(applicationContext)
-	exit_code = applicationContext.app.exec_()
+	exit_code = -1
+	try:
+		exit_code = applicationContext.app.exec_()
+	except:
+		exit_code = applicationContext.exec_()
 	sys.exit(exit_code)


### PR DESCRIPTION
This is not actually meant for merging :P Just a pull request to show what I had to do to run this without fbs.

Is there a way to do a runtime check if you're running the application through fbs or not? Because the neat solution would be like
>if (through_fbs):
>    import fbs_stuff
>else:
>    do_the_qapplication_stuff_instead

If there was a way to run it without fbs/do a runtime check if its run through fbs, I could easily make an ebuild for this program for Gentoo. That would be neat for me at least :)