### PR TITLE
Change the dpi validator to only run at editingFinished

### DIFF
--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -63,7 +63,6 @@ class ConfigurationWindow(QWidget):
 
 		self.dpiLineEdit = QLineEdit()
 		self.dpiLineEdit.setToolTip('sets the dots per inch')
-		self.dpiLineEdit.setValidator(QIntModuloValidator(50, 200, 16000))
 
 		self.dpiGroupBox = QGroupBox("dots per inch")
 		self.dpiGroupBoxLayout = QVBoxLayout()
@@ -173,11 +172,14 @@ class MainWindow(QMainWindow):
 
 		def onDpiLineEditChanged():
 			try:
+				self.configurationWindow.dpiLineEdit.setValidator(QIntModuloValidator(50, 200, 16000))
 				self.configurationWindow.dpiSlider.setValue(int(self.configurationWindow.dpiLineEdit.text()))
 			except:
 				self.showErrorWindow()
+			finally:
+				self.configurationWindow.dpiLineEdit.setValidator(None)
 
-		self.configurationWindow.dpiLineEdit.textEdited.connect(lambda: onDpiLineEditChanged())
+		self.configurationWindow.dpiLineEdit.editingFinished.connect(lambda: onDpiLineEditChanged())
 
 		self.setCentralWidget(self.configurationWindow)
 		self.setFixedSize(self.sizeHint())


### PR DESCRIPTION
Had to do it so the validator only runs after editing is completely finished, and only then.

I had to set and then unset the validator (thus in a way doing the validation manually), or else the validator always runs no matter what editing you do. When setting it like this, it only runs after editing is actually finished.